### PR TITLE
[Feat] SearchViewController의 전반적인 UI 틀 구성

### DIFF
--- a/CloneIKEA/CloneIKEA.xcodeproj/project.pbxproj
+++ b/CloneIKEA/CloneIKEA.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0737EE5928E9326C00E4057F /* CloneIKEAUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0737EE5828E9326C00E4057F /* CloneIKEAUITests.swift */; };
 		0737EE5B28E9326C00E4057F /* CloneIKEAUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0737EE5A28E9326C00E4057F /* CloneIKEAUITestsLaunchTests.swift */; };
 		0737EE6A28E96B1000E4057F /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0737EE6928E96B1000E4057F /* SearchViewController.swift */; };
+		0737EE6C28E9732E00E4057F /* UIStackView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0737EE6B28E9732E00E4057F /* UIStackView+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +52,7 @@
 		0737EE5828E9326C00E4057F /* CloneIKEAUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloneIKEAUITests.swift; sourceTree = "<group>"; };
 		0737EE5A28E9326C00E4057F /* CloneIKEAUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloneIKEAUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		0737EE6928E96B1000E4057F /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		0737EE6B28E9732E00E4057F /* UIStackView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 				0737EE4228E9326C00E4057F /* LaunchScreen.storyboard */,
 				0737EE4528E9326C00E4057F /* Info.plist */,
 				0737EE6928E96B1000E4057F /* SearchViewController.swift */,
+				0737EE6B28E9732E00E4057F /* UIStackView+Extension.swift */,
 			);
 			path = CloneIKEA;
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 				0737EE3C28E9326B00E4057F /* ViewController.swift in Sources */,
 				0737EE3828E9326B00E4057F /* AppDelegate.swift in Sources */,
 				0737EE6A28E96B1000E4057F /* SearchViewController.swift in Sources */,
+				0737EE6C28E9732E00E4057F /* UIStackView+Extension.swift in Sources */,
 				0737EE3A28E9326B00E4057F /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CloneIKEA/CloneIKEA.xcodeproj/project.pbxproj
+++ b/CloneIKEA/CloneIKEA.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0737EE4F28E9326C00E4057F /* CloneIKEATests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0737EE4E28E9326C00E4057F /* CloneIKEATests.swift */; };
 		0737EE5928E9326C00E4057F /* CloneIKEAUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0737EE5828E9326C00E4057F /* CloneIKEAUITests.swift */; };
 		0737EE5B28E9326C00E4057F /* CloneIKEAUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0737EE5A28E9326C00E4057F /* CloneIKEAUITestsLaunchTests.swift */; };
+		0737EE6A28E96B1000E4057F /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0737EE6928E96B1000E4057F /* SearchViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +50,7 @@
 		0737EE5428E9326C00E4057F /* CloneIKEAUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CloneIKEAUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0737EE5828E9326C00E4057F /* CloneIKEAUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloneIKEAUITests.swift; sourceTree = "<group>"; };
 		0737EE5A28E9326C00E4057F /* CloneIKEAUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloneIKEAUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		0737EE6928E96B1000E4057F /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,6 +108,7 @@
 				0737EE4028E9326C00E4057F /* Assets.xcassets */,
 				0737EE4228E9326C00E4057F /* LaunchScreen.storyboard */,
 				0737EE4528E9326C00E4057F /* Info.plist */,
+				0737EE6928E96B1000E4057F /* SearchViewController.swift */,
 			);
 			path = CloneIKEA;
 			sourceTree = "<group>";
@@ -260,6 +263,7 @@
 			files = (
 				0737EE3C28E9326B00E4057F /* ViewController.swift in Sources */,
 				0737EE3828E9326B00E4057F /* AppDelegate.swift in Sources */,
+				0737EE6A28E96B1000E4057F /* SearchViewController.swift in Sources */,
 				0737EE3A28E9326B00E4057F /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/CloneIKEA/CloneIKEA/SearchViewController.swift
+++ b/CloneIKEA/CloneIKEA/SearchViewController.swift
@@ -1,0 +1,17 @@
+//
+//  SearchViewController.swift
+//  CloneIKEA
+//
+//  Created by 김수진 on 2022/10/02.
+//
+
+import UIKit
+
+class SearchViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+    }
+
+}

--- a/CloneIKEA/CloneIKEA/SearchViewController.swift
+++ b/CloneIKEA/CloneIKEA/SearchViewController.swift
@@ -8,10 +8,54 @@
 import UIKit
 
 class SearchViewController: UIViewController {
-
+    
+    private var safeArea: UILayoutGuide {
+        get { self.view.safeAreaLayoutGuide }
+    }
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 20
+        return stackView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        render()
+    }
+    
+    func render() {
+        renderScrollView()
+        renderStackView()
+    }
+    
+    private func renderScrollView() {
+        view.addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.frameLayoutGuide.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            scrollView.frameLayoutGuide.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            scrollView.frameLayoutGuide.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            scrollView.frameLayoutGuide.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+        ])
+    }
+    
+    private func renderStackView() {
+        scrollView.addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            
+            stackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
+        ])
     }
 
 }

--- a/CloneIKEA/CloneIKEA/SearchViewController.swift
+++ b/CloneIKEA/CloneIKEA/SearchViewController.swift
@@ -86,6 +86,13 @@ class SearchViewController: UIViewController {
             
             stackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
         ])
+        
+        stackView.addArrangedSubviews(titleSectionView,
+                                      recentProductSectionView,
+                                      productCategorySectionView,
+                                      campaignSectionView,
+                                      popularProductSectionView,
+                                      informationSectionView)
     }
 
 }

--- a/CloneIKEA/CloneIKEA/SearchViewController.swift
+++ b/CloneIKEA/CloneIKEA/SearchViewController.swift
@@ -25,6 +25,36 @@ class SearchViewController: UIViewController {
         stackView.spacing = 20
         return stackView
     }()
+    private let titleSectionView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    private let recentProductSectionView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    private let productCategorySectionView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    private let campaignSectionView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    private let popularProductSectionView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    private let informationSectionView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/CloneIKEA/CloneIKEA/UIStackView+Extension.swift
+++ b/CloneIKEA/CloneIKEA/UIStackView+Extension.swift
@@ -1,0 +1,17 @@
+//
+//  UIStackView+Extension.swift
+//  CloneIKEA
+//
+//  Created by 김수진 on 2022/10/02.
+//
+
+import Foundation
+import UIKit
+
+extension UIStackView {
+    func addArrangedSubviews(_ views: UIView...) {
+        views.forEach { [weak self] view in
+            self?.addArrangedSubview(view)
+        }
+    }
+}


### PR DESCRIPTION
## 👀 관련 이슈
- close #1 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 👀 배경
현재 목표로 하고 있는 SearchViewController는 다양한 뷰의 구성으로 복잡하게 이루어져 있습니다.
각 부분을 컴포넌트화 하여 구현하기 위해, 전반적인 틀을 잡으며 구역을 분할하는 과정이 필요하므로, 이를 진행했습니다.
아래 이미지는 목표하는 화면입니다.
<img src="https://user-images.githubusercontent.com/20871603/193444534-2ce0aab5-2963-45df-961c-2348664e3f4d.png" width="30%" height="30%">
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 👀 작업 내용
SearchViewController의 전반적인 구성은 UITableView나 UICollectionView보다는 UIScrollView + UIStackView로 진행했습니다.
각각의 영역들을 하나의 UICollectionView로 취급할 만한 공통적인 특성들도 없었고, 터치 이벤트들에 대한 관리도 따로 비활성화 시키는 것보다 애초에 들어가있지 않은 UIScrollView + UIStackView 방식이 더 편하게 구현할 수 있을 것 같았습니다.

따라서, 구현사항은
UIScrollView + UIStackView로 전반적인 프레임을 잡고,
UIStackView에 분할한 각 영역뷰들을 추가해주었습니다.

각 영역은 다음과 같이 구분됩니다.
- titleSectionView (해당 화면에 대한 제목과 서치바가 들어갑니다.)
- recentProductSectionView (최근 본 제품에 대한 정보가 들어갑니다.)
- productCategorySectionView (제품 찾아보기에 대한 정보가 들어갑니다.)
- campaignSectionView (캠페인 정보가 들어갑니다.)
- popularProductSectionView (인기 제품에 대한 정보가 들어갑니다.)
- informationSectionView (그 외 기타 정보가 들어갑니다.)

<!-- 구현/변경한 내용을 적어주세요 -->

## 👀 PR Point
전반적인 구성이 적합하여, 앞으로 유지보수 및 수정, 확장 등에 적절할 지 함께 고민해주시면 감사하겠습니다.
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 👀 참고 사항

<!-- 참고할 사항(스크린샷, 실행 시 유의할 점, 참고 링크)이 있다면 적어주세요. -->